### PR TITLE
fix(settings): remove manual .env loading

### DIFF
--- a/backend/src/settings.py
+++ b/backend/src/settings.py
@@ -1,22 +1,6 @@
-from pathlib import Path
-
-from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from repositories.mongo.mongo_settings import MongoSettings
-
-
-def find_project_root(marker="pyproject.toml"):
-    current = Path(__file__).resolve()
-    for parent in current.parents:
-        if (parent / marker).exists():
-            return parent
-    msg = f"Could not find {marker} in any parent directory."
-    raise FileNotFoundError(msg)
-
-
-ROOT_DIR = find_project_root()
-load_dotenv(ROOT_DIR / ".env")
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
This change simplifies the Settings configuration by removing manual .env loading and project root detection. Environment variables are now read / parsed directly via pydantic-settings. The .env file is loaded into the environment by uv at runtime, so no manual .env loading is needed in application code.
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/LeoKle/cs50-moodle-bridge/tree/main) ([729f07f](https://github.com/LeoKle/cs50-moodle-bridge/commit/729f07fa7c7837e355219aabfdfbaaedf3712633)) | [#34](https://github.com/LeoKle/cs50-moodle-bridge/pull/34) ([da219a2](https://github.com/LeoKle/cs50-moodle-bridge/commit/da219a278ecc4a5b129ab83b3251fe638bb8d05a)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                                    95.5% |                                                                                                                                                                 96.4% | +0.9% |
| **Test Execution Time** |                                                                                                                                                                       1s |                                                                                                                                                                    2s |   +1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (729f07f) | #34 (da219a2) |  +/-  |
  |---------------------|----------------|---------------|-------|
+ | Coverage            |          95.5% |         96.4% | +0.9% |
  |   Files             |             19 |            19 |     0 |
  |   Lines             |            178 |           167 |   -11 |
- |   Covered           |            170 |           161 |    -9 |
- | Test Execution Time |             1s |            2s |   +1s |
```

</details>


### Code coverage of files in pull request scope (75.0% → 66.6%)

|                                                                       Files                                                                       | Coverage |  +/-  |  Status  |
|---------------------------------------------------------------------------------------------------------------------------------------------------|---------:|------:|---------:|
| [backend/src/settings.py](https://github.com/LeoKle/cs50-moodle-bridge/blob/706bd120d28a5c75ed94ae46312d6d8fcdd64241/backend%2Fsrc%2Fsettings.py) | 66.6%    | -8.4% | modified |

---
Reported by octocov
<!-- octocov -->
