### PR TITLE
feat(integration-tests): add course controller integration tests

### DIFF
--- a/backend/tests/integration/api/conftest.py
+++ b/backend/tests/integration/api/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import app, container
+from api.v1.controllers import course
+from services.course import CourseService
+
+
+@pytest.fixture
+def client_course(course_repository):
+    """
+    Provides a FastAPI TestClient with a clean container for each test.
+    Dependencies can be overridden before yielding the client.
+    """
+    container.reset_override()
+
+    course_service = CourseService(course_repository)
+
+    container.course_service.override(course_service)
+
+    container.wire(modules=[course])
+
+    with TestClient(app) as c:
+        yield c

--- a/backend/tests/integration/api/v1/controllers/test_course_controller_integration.py
+++ b/backend/tests/integration/api/v1/controllers/test_course_controller_integration.py
@@ -1,0 +1,135 @@
+import pytest
+from fastapi import status
+
+from api.models.course import CourseCreate, CourseOut, CourseUpdate
+
+pytestmark = pytest.mark.integration
+
+
+def test_get_course_success(client_course):
+    response = client_course.get("/api/v1/courses/1")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_courses(client_course):
+    response = client_course.get("/api/v1/courses")
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 0
+
+
+def test_create_course_success(client_course):
+    payload = CourseCreate(name="New Course", cs50_id=60, exercise_ids=[])
+
+    response = client_course.post("/api/v1/courses", json=payload.model_dump())
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    model = CourseOut(**data)
+    assert model.name == payload.name
+    assert model.cs50_id == payload.cs50_id
+    assert model.exercise_ids == payload.exercise_ids
+    assert model.id != ""  # ensure ID is generated
+
+
+def test_create_course_missing_fields(client_course):
+    payload = {}
+    response = client_course.post("/api/v1/courses", json=payload)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+def test_update_course_success(client_course):
+    payload = CourseCreate(name="New Course", cs50_id=60, exercise_ids=[])
+
+    response = client_course.post("/api/v1/courses", json=payload.model_dump())
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    created = CourseOut(**data)
+
+    payload = CourseUpdate(name="Updated Name")
+
+    response = client_course.patch(f"/api/v1/courses/{created.id}", json=payload.model_dump())
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    model = CourseOut(**data)
+    assert model.name == payload.name
+
+
+def test_update_course_partial_update(client_course):
+    payload = CourseCreate(name="New Course", cs50_id=60, exercise_ids=[])
+
+    response = client_course.post("/api/v1/courses", json=payload.model_dump())
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    created = CourseOut(**data)
+
+    payload = CourseUpdate(exercise_ids=["ex1", "ex2"])
+    response = client_course.patch(f"/api/v1/courses/{created.id}", json=payload.model_dump())
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    updated = CourseOut(**data)
+    assert updated.id == created.id
+    assert updated.exercise_ids == payload.exercise_ids
+
+
+def test_update_course_not_found(client_course):
+    payload = CourseUpdate(name="Does Not Exist")
+    response = client_course.patch("/api/v1/courses/nonexistent", json=payload.model_dump())
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert "not found" in data["detail"].lower()
+
+
+def test_delete_course_success(client_course):
+    payload = CourseCreate(name="New Course", cs50_id=60, exercise_ids=[])
+
+    response = client_course.post("/api/v1/courses", json=payload.model_dump())
+    assert response.status_code == status.HTTP_200_OK
+
+    data = response.json()
+    created = CourseOut(**data)
+
+    response = client_course.delete(f"/api/v1/courses/{created.id}")
+    assert response.status_code == status.HTTP_200_OK
+
+    response = client_course.get("/api/v1/courses/1")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_delete_course_not_found(client_course):
+    response = client_course.delete("/api/v1/courses/nonexistent")
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    data = response.json()
+    assert "not found" in data["detail"].lower()
+
+
+def test_create_and_delete_multiple_courses(client_course):
+    course_ids = []
+    for i in range(3):
+        payload = CourseCreate(name=f"Course {i}", cs50_id=i, exercise_ids=[])
+        response = client_course.post("/api/v1/courses", json=payload.model_dump())
+        assert response.status_code == status.HTTP_200_OK
+        course_ids.append(response.json()["id"])
+
+    # verify all exist
+    response = client_course.get("/api/v1/courses")
+    data = response.json()
+    existing_ids = {c["id"] for c in data}
+    for cid in course_ids:
+        assert cid in existing_ids
+
+    # delete all
+    for cid in course_ids:
+        response = client_course.delete(f"/api/v1/courses/{cid}")
+        assert response.status_code == status.HTTP_200_OK
+
+    # verify delete
+    response = client_course.get("/api/v1/courses")
+    data = response.json()
+    remaining_ids = {c["id"] for c in data}
+    for cid in course_ids:
+        assert cid not in remaining_ids

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,12 @@
+import mongomock
+import pytest
+
+from repositories.mongo.course_repository import MongoCourseRepository
+
+
+@pytest.fixture
+def course_repository():
+    client = mongomock.MongoClient()
+    db = client["test_db"]
+    collection = db["courses"]
+    return MongoCourseRepository(collection=collection)


### PR DESCRIPTION
adds integration tests starting with course controller, using the production version of CourseService and MongoCourseRepository with only the MongoClient being mocked
<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/LeoKle/cs50-moodle-bridge/tree/main) ([ed89f52](https://github.com/LeoKle/cs50-moodle-bridge/commit/ed89f52f55d614f51dc488fde1b77fbaea4594fe)) | [#65](https://github.com/LeoKle/cs50-moodle-bridge/pull/65) ([63f20a0](https://github.com/LeoKle/cs50-moodle-bridge/commit/63f20a0bc7ae28b2d9c54a58d7a081e031dae14c)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                                    97.1% |                                                                                                                                                                 97.1% | 0.0% |
| **Test Execution Time** |                                                                                                                                                                       3s |                                                                                                                                                                    2s |  -1s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (ed89f52) | #65 (63f20a0) | +/-  |
  |---------------------|----------------|---------------|------|
  | Coverage            |          97.1% |         97.1% | 0.0% |
  |   Files             |             47 |            47 |    0 |
  |   Lines             |            593 |           593 |    0 |
  |   Covered           |            576 |           576 |    0 |
+ | Test Execution Time |             3s |            2s |  -1s |
```

</details>



---
Reported by octocov
<!-- octocov -->
