### PR TITLE
fix(action): update pytest command to use test type input

### DIFF
--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -16,5 +16,5 @@ runs:
       working-directory: ${{ inputs.directory }}
       run: |
         echo "Running ${{ inputs.test_type }} tests in ${{ inputs.directory }}..."
-        uv run pytest -m "unit" --maxfail=1 --disable-warnings --cov-append --cov-report=xml:coverage.xml || \
+        uv run pytest -m "${{ inputs.test_type }}" --maxfail=1 --disable-warnings --cov-append --cov-report=xml:coverage.xml || \
         (e=$?; [ $e -eq 5 ] && echo "No tests collected, skipping" || exit $e)


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|                         | [main](https://github.com/LeoKle/cs50-moodle-bridge/tree/main) ([3cc968b](https://github.com/LeoKle/cs50-moodle-bridge/commit/3cc968b873779a97963796c398d16f4e8304ed27)) | [#68](https://github.com/LeoKle/cs50-moodle-bridge/pull/68) ([cfd3643](https://github.com/LeoKle/cs50-moodle-bridge/commit/cfd3643c07509b5e346888d79c2c3c344a3dec98)) | +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-----:|
| **Coverage**            |                                                                                                                                                                    97.1% |                                                                                                                                                                 97.1% | 0.0% |
| **Test Execution Time** |                                                                                                                                                                       2s |                                                                                                                                                                    2s |   0s |

<details>

<summary>Details</summary>

``` diff
  |                     | main (3cc968b) | #68 (cfd3643) | +/-  |
  |---------------------|----------------|---------------|------|
  | Coverage            |          97.1% |         97.1% | 0.0% |
  |   Files             |             48 |            48 |    0 |
  |   Lines             |            629 |           629 |    0 |
  |   Covered           |            611 |           611 |    0 |
  | Test Execution Time |             2s |            2s |   0s |
```

</details>



---
Reported by octocov
<!-- octocov -->
